### PR TITLE
fix: lowercase admin address

### DIFF
--- a/src/writers.ts
+++ b/src/writers.ts
@@ -39,7 +39,7 @@ function computeExpiration(
   blockTimestamp: number
 ): Date {
   // If the payment is from the admin address, simply return the expiration date from the metadata
-  if (payment.sender === ADMIN_ADDRESS && payment.amount_raw == 0n) {
+  if (payment.sender.toLowerCase() === ADMIN_ADDRESS && payment.amount_raw == 0n) {
     const date = new Date(metadata.params.expiration * MILLISECONDS);
     if (isNaN(date.getTime())) {
       return new Date(0);
@@ -89,7 +89,7 @@ export function createEvmWriters(indexerName: string) {
   const handlePaymentReceived: evm.Writer = async ({ block, tx, event }) => {
     if (!block || !event) return;
 
-    const sender = event.args.sender.toLowerCase();
+    const sender = event.args.sender;
     const tokenAddress = event.args.token.toLowerCase();
     const amountRaw = BigInt(event.args.amount);
     const amountDecimal = Number(amountRaw) / DECIMALS;

--- a/src/writers.ts
+++ b/src/writers.ts
@@ -39,7 +39,7 @@ function computeExpiration(
   blockTimestamp: number
 ): Date {
   // If the payment is from the admin address, simply return the expiration date from the metadata
-  if (payment.sender.toLowerCase() === ADMIN_ADDRESS.toLowerCase()) {
+  if (payment.sender === ADMIN_ADDRESS) {
     return new Date(metadata.params.expiration * MILLISECONDS);
   }
 

--- a/src/writers.ts
+++ b/src/writers.ts
@@ -39,7 +39,7 @@ function computeExpiration(
   blockTimestamp: number
 ): Date {
   // If the payment is from the admin address, simply return the expiration date from the metadata
-  if (payment.sender === ADMIN_ADDRESS) {
+  if (payment.sender === ADMIN_ADDRESS && payment.amount_raw == 0n) {
     const date = new Date(metadata.params.expiration * MILLISECONDS);
     if (isNaN(date.getTime())) {
       return new Date(0);

--- a/src/writers.ts
+++ b/src/writers.ts
@@ -17,7 +17,9 @@ const DAYS_PER_MONTH = (365 * 3 + 366) / 48; // Accounting for leap years, which
 const MONTHLY_PRICE_PER_DAY = TURBO_MONTHLY_PRICE / DAYS_PER_MONTH;
 const MONTHLY_PRICE_PER_SECOND = MONTHLY_PRICE_PER_DAY / (24 * 60 * 60); // 24 hours * 60 minutes * 60 seconds
 
-const ADMIN_ADDRESS = process.env.ADMIN_ADDRESS || '0x8C28Cf33d9Fd3D0293f963b1cd27e3FF422B425c';
+const ADMIN_ADDRESS = (
+  process.env.ADMIN_ADDRESS || '0x8C28Cf33d9Fd3D0293f963b1cd27e3FF422B425c'
+).toLowerCase();
 
 function getTokenSymbol(tokenAddress: string, chain: string) {
   return tokens[chain][tokenAddress];
@@ -45,7 +47,7 @@ function computeExpiration(
     // Return early because the payment is not enough to extend the expiration
     if (space.turbo_expiration) {
       // User already had an expiration date, leave it untouched.
-      return new Date(space.turbo_expiration * 1000);
+      return new Date(space.turbo_expiration * MILLISECONDS);
     } else {
       // User didn't have an expiration date, leave it to 0
       return new Date(0);
@@ -82,7 +84,7 @@ export function createEvmWriters(indexerName: string) {
   const handlePaymentReceived: evm.Writer = async ({ block, tx, event }) => {
     if (!block || !event) return;
 
-    const sender = event.args.sender;
+    const sender = event.args.sender.toLowerCase();
     const tokenAddress = event.args.token.toLowerCase();
     const amountRaw = BigInt(event.args.amount);
     const amountDecimal = Number(amountRaw) / DECIMALS;

--- a/src/writers.ts
+++ b/src/writers.ts
@@ -40,7 +40,12 @@ function computeExpiration(
 ): Date {
   // If the payment is from the admin address, simply return the expiration date from the metadata
   if (payment.sender === ADMIN_ADDRESS) {
-    return new Date(metadata.params.expiration * MILLISECONDS);
+    const date = new Date(metadata.params.expiration * MILLISECONDS);
+    if (isNaN(date.getTime())) {
+      return new Date(0);
+    } else {
+      return date;
+    }
   }
 
   if (payment.amount_raw < TURBO_MONTHLY_PRICE) {


### PR DESCRIPTION
- Lowercases ADMIN_ADDRESS
- Uses `MILLISECONDS` instead of hardcoded `1000` value
- Returns `Date(0)` if `expiration` is not in `metadata` or if `expiration` is invalid
- Treat payment as a regular payment if ADMIN attaches money to the payment
