### PR TITLE
feat: add Discord notifications for new payment

### DIFF
--- a/src/discord.ts
+++ b/src/discord.ts
@@ -18,7 +18,7 @@ export async function notifyPayment(
 
   const content = `**New payment of ${payment.amount_decimal} ${payment.token_symbol} for [${
     payment.space
-  }](https://${INDEX_TESTNET ? 'testnet.' : ''}snapshot.box/#/s${INDEX_TESTNET ? '-sn.' : ''}:${
+  }](https://${INDEX_TESTNET ? 'testnet.' : ''}snapshot.box/#/s${INDEX_TESTNET ? '-tn' : ''}:${
     payment.space
   })**\nFrom [${payment.sender}](https://${INDEX_TESTNET ? 'sepolia.' : ''}etherscan.io/address/${
     payment.sender

--- a/src/discord.ts
+++ b/src/discord.ts
@@ -1,0 +1,36 @@
+import { Payment, Space } from '../.checkpoint/models';
+
+const DISCORD_WEBHOOK_URL = process.env.DISCORD_WEBHOOK_URL;
+const INDEX_TESTNET = process.env.INDEX_TESTNET;
+
+export async function notifyPayment(
+  payment: Payment,
+  space: Space,
+  block: any,
+  tx: any
+): Promise<void> {
+  if (!DISCORD_WEBHOOK_URL) return;
+
+  const now = ~~(Date.now() / 1e3);
+  const recentThreshold = now - 60 * 30;
+
+  if (block.timestamp < recentThreshold) return;
+
+  const content = `**New payment of ${payment.amount_decimal} ${payment.token_symbol} for [${
+    payment.space
+  }](https://${INDEX_TESTNET ? 'testnet.' : ''}snapshot.box/#/s${INDEX_TESTNET ? '-sn.' : ''}:${
+    payment.space
+  })**\nFrom [${payment.sender}](https://${INDEX_TESTNET ? 'sepolia.' : ''}etherscan.io/address/${
+    payment.sender
+  }), expiration : ${space.turbo_expiration_date}\n<https://${
+    INDEX_TESTNET ? 'sepolia.' : ''
+  }etherscan.io/tx/${tx.hash}>`;
+
+  await fetch(DISCORD_WEBHOOK_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ content })
+  });
+
+  return;
+}

--- a/src/writers.ts
+++ b/src/writers.ts
@@ -2,6 +2,7 @@ import { evm } from '@snapshot-labs/checkpoint';
 import { Payment, Space } from '../.checkpoint/models';
 import { getJSON } from './utils';
 import tokens from './payment_tokens.json';
+import { notifyPayment } from './discord';
 
 const MILLISECONDS = 1000;
 const DECIMALS = 1e6; // USDC and USDT both have 6 decimals
@@ -131,6 +132,8 @@ export function createEvmWriters(indexerName: string) {
     space.turbo_expiration_date = expirationDate.toDateString();
 
     await space.save();
+
+    notifyPayment(payment, space, block, tx);
   };
 
   return {


### PR DESCRIPTION
Send a Discord message using Discord webhook to notify for a new payment. The message will only be sent if the tx happened 30mn ago (this is to avoid having all payment triggering message when we resync the API).