### PR TITLE
feat: migrated turbo spaces list

### DIFF
--- a/src/writers.ts
+++ b/src/writers.ts
@@ -22,6 +22,10 @@ const ADMIN_ADDRESS = (
   process.env.ADMIN_ADDRESS || '0x8C28Cf33d9Fd3D0293f963b1cd27e3FF422B425c'
 ).toLowerCase();
 
+const MIGRATED_TURBO_SPACES = {
+  's:mimo.eth': 's:parallel-protocol.eth'
+};
+
 function getTokenSymbol(tokenAddress: string, chain: string) {
   return tokens[chain][tokenAddress];
 }
@@ -107,6 +111,8 @@ export function createEvmWriters(indexerName: string) {
 
     payment.barcode = barcode;
     const metadata = await getJSON(barcode);
+    metadata.params.space = MIGRATED_TURBO_SPACES[metadata.params.space] ?? metadata.params.space;
+    console.log('Payment received for space', metadata.params.space);
 
     payment.block = block.number;
     payment.timestamp = block.timestamp;


### PR DESCRIPTION
Closes https://github.com/snapshot-labs/workflow/issues/649

### Summary
- added migrated turbo spaces mapping for address updates
- logged payment details for better tracking


### How to test:
- Update the start block:
```bash
diff --git a/src/config.ts b/src/config.ts
index 7c0c3b2..c4785f0 100644
--- a/src/config.ts
+++ b/src/config.ts
@@ -10,7 +10,7 @@ const CONFIG = {
   eth: {
     networkNodeUrl: 'https://rpc.brovider.xyz/1',
     contract: '0xe40bfeb5a3014c9b98597088ca71eccdc27ca410',
-    start: 21966192
+    start: 23185322
   }
 };
```
- Run `yarn dev`
- Use these queries: http://localhost:3000/?query=query%20Spaces%20%7B%0A%20%20spaces%20%7B%0A%20%20%20%20id%0A%20%20%20%20turbo_expiration_date%0A%20%20%20%20_indexer%0A%20%20%7D%0A%7D%0A%0Aquery%20Payments%20%7B%0A%20%20payments%20%7B%0A%20%20%20%20id%0A%20%20%20%20space%0A%20%20%20%20amount_raw%0A%20%20%20%20block%0A%20%20%7D%0A%7D%0A&operationName=Payments
- Should show new space ids instead of old one
 