### PR TITLE
fix: prevent crashes from failed metadata fetches

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@types/node": "^24.10.0",
     "cors": "^2.8.5",
     "dotenv": "^16.0.1",
+    "exponential-backoff": "^3.1.3",
     "express": "^4.18.1",
     "nodemon": "^2.0.19",
     "starknet": "^5.19.3",

--- a/src/expirationMonitor.ts
+++ b/src/expirationMonitor.ts
@@ -19,7 +19,7 @@ export async function startExpirationMonitor(
     return;
   }
 
-  const { knex }  = checkpoint.getBaseContext();
+  const { knex } = checkpoint.getBaseContext();
   const client = createPublicClient({
     transport: http(config.network_node_url)
   });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -16,11 +16,36 @@ export function getUrl(uri: string, gateway = 'pineapple.fyi') {
   return uri;
 }
 
-export async function getJSON(uri: string) {
+export async function getJSON(uri: string, retries = 3) {
   const url = getUrl(uri);
-  if (!url) throw new Error('Invalid URI');
+  if (!url) {
+    console.error(`Invalid URI: ${uri}`);
+    return null;
+  }
 
-  return fetch(url).then(res => res.json());
+  let lastError: Error | null = null;
+
+  for (let attempt = 1; attempt <= retries; attempt++) {
+    try {
+      const res = await fetch(url);
+      if (!res.ok) {
+        throw new Error(`HTTP error! status: ${res.status}`);
+      }
+      return await res.json();
+    } catch (error) {
+      lastError = error as Error;
+
+      if (lastError.message.includes('is not valid JSON')) {
+        console.error(`Invalid JSON from ${uri}:`, lastError);
+        return null;
+      }
+
+      if (attempt < retries) await sleep(2000);
+    }
+  }
+
+  console.error(`Failed to fetch or parse JSON from ${uri}:`, lastError);
+  return null;
 }
 
 export const sleep = (ms: number) =>

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -24,7 +24,7 @@ export async function getJSON(uri: string) {
     throw new Error(`Invalid URI: ${uri}`);
   }
 
-  return await backOff(
+  return backOff(
     async () => {
       const res = await fetch(url, {
         signal: AbortSignal.timeout(15000)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import { backOff } from "exponential-backoff";
+import { backOff } from 'exponential-backoff';
 
 export function getUrl(uri: string, gateway = 'pineapple.fyi') {
   const ipfsGateway = `https://${gateway}`;

--- a/src/writers.ts
+++ b/src/writers.ts
@@ -126,8 +126,8 @@ export function createEvmWriters(indexerName: string) {
     let metadata;
     try {
       metadata = await getJSON(barcode);
-    } catch (e) {
-      console.error('Failed to fetch metadata for barcode:', e);
+    } catch (err) {
+      console.error('Failed to fetch metadata for barcode:', err);
       return;
     }
     if (!metadata?.params?.space) return;

--- a/src/writers.ts
+++ b/src/writers.ts
@@ -127,7 +127,7 @@ export function createEvmWriters(indexerName: string) {
     try {
       metadata = await getJSON(barcode);
     } catch (e) {
-      console.log('Failed to fetch metadata for barcode:', e);
+      console.error('Failed to fetch metadata for barcode:', e);
       return;
     }
     if (!metadata?.params?.space) return;

--- a/src/writers.ts
+++ b/src/writers.ts
@@ -123,7 +123,13 @@ export function createEvmWriters(indexerName: string) {
     payment.amount_decimal = amountDecimal.toString();
 
     payment.barcode = barcode;
-    const metadata = await getJSON(barcode);
+    let metadata;
+    try {
+      metadata = await getJSON(barcode);
+    } catch (e) {
+      console.log('Failed to fetch metadata for barcode:', barcode);
+      return;
+    }
     if (!metadata?.params?.space) return;
 
     metadata.params.space =

--- a/src/writers.ts
+++ b/src/writers.ts
@@ -124,6 +124,8 @@ export function createEvmWriters(indexerName: string) {
 
     payment.barcode = barcode;
     const metadata = await getJSON(barcode);
+    if (!metadata?.params?.space) return;
+
     metadata.params.space =
       MIGRATED_TURBO_SPACES[metadata.params.space] ?? metadata.params.space;
     console.log('Payment received for space', metadata.params.space);

--- a/src/writers.ts
+++ b/src/writers.ts
@@ -127,7 +127,7 @@ export function createEvmWriters(indexerName: string) {
     try {
       metadata = await getJSON(barcode);
     } catch (e) {
-      console.log('Failed to fetch metadata for barcode:', barcode);
+      console.log('Failed to fetch metadata for barcode:', e);
       return;
     }
     if (!metadata?.params?.space) return;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1283,6 +1283,11 @@ eventemitter3@5.0.1:
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-5.0.1.tgz#53f5ffd0a492ac800721bb42c66b841de96423c4"
   integrity sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==
 
+exponential-backoff@^3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/exponential-backoff/-/exponential-backoff-3.1.3.tgz#51cf92c1c0493c766053f9d3abee4434c244d2f6"
+  integrity sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==
+
 express-graphql@^0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/express-graphql/-/express-graphql-0.12.0.tgz#58deabc309909ca2c9fe2f83f5fbe94429aa23df"


### PR DESCRIPTION
Fixes https://github.com/snapshot-labs/workflow/issues/682

Add retry logic (3 attempts) and null checks to handle network failures and malformed metadata

maybe we can use some library to replace this?