### PR TITLE
refactor: extract reusable turbo and discord helpers

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -14,6 +14,13 @@ const CONFIG = {
   }
 };
 
+export const NETWORK = process.env.INDEX_TESTNET ? 'sep' : 'eth';
+
+export const TURBO_PRICE_USD = {
+  monthly: 600,
+  yearly: 6000
+};
+
 export function createConfig(
   indexerName: keyof typeof CONFIG
 ): CheckpointConfig {

--- a/src/discord.ts
+++ b/src/discord.ts
@@ -9,60 +9,66 @@ const INDEX_TESTNET = process.env.INDEX_TESTNET;
 
 const SNAPSHOT_BASE_URL = `https://${INDEX_TESTNET ? 'testnet.' : ''}snapshot.box`;
 
+type DiscordMessage = {
+  content?: string;
+  embeds?: Record<string, unknown>[];
+};
+
+async function postToDiscord(body: DiscordMessage): Promise<void> {
+  if (!DISCORD_WEBHOOK_URL) return;
+
+  await fetch(DISCORD_WEBHOOK_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body)
+  });
+}
+
+const isRecent = (timestamp: number) =>
+  timestamp >= ~~(Date.now() / 1e3) - 60 * 60; // within the last hour
+
 export async function notifyPayment(
   payment: Payment,
   space: Space,
   block: GetBlockReturnType,
   txHash: string
 ): Promise<void> {
-  if (!DISCORD_WEBHOOK_URL) return;
-
-  const now = ~~(Date.now() / 1e3);
-  const recentThreshold = now - 60 * 60; // 1 hour
-
   const blockTimestamp = Number(block.timestamp);
-
-  if (blockTimestamp < recentThreshold) return;
+  if (!isRecent(blockTimestamp)) return;
 
   const explorerBaseUrl = `https://${INDEX_TESTNET ? 'sepolia.' : ''}etherscan.io`;
 
-  await fetch(DISCORD_WEBHOOK_URL, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      embeds: [
-        {
-          title: `💰 New payment of ${payment.amount_decimal} ${payment.token_symbol}`,
-          url: `${explorerBaseUrl}/tx/${txHash}`,
-          author: {
-            name: payment.sender,
-            icon_url: `https://cdn.stamp.fyi/avatar/${payment.sender}`,
-            link: `${explorerBaseUrl}/address/${payment.sender}`
+  await postToDiscord({
+    embeds: [
+      {
+        title: `💰 New payment of ${payment.amount_decimal} ${payment.token_symbol}`,
+        url: `${explorerBaseUrl}/tx/${txHash}`,
+        author: {
+          name: payment.sender,
+          icon_url: `https://cdn.stamp.fyi/avatar/${payment.sender}`,
+          link: `${explorerBaseUrl}/address/${payment.sender}`
+        },
+        fields: [
+          {
+            name: 'Space',
+            value: `[${payment.space}](${SNAPSHOT_BASE_URL}/#/${payment.space})`,
+            inline: true
           },
-          fields: [
-            {
-              name: 'Space',
-              value: `[${payment.space}](${SNAPSHOT_BASE_URL}/#/${payment.space})`,
-              inline: true
-            },
-            {
-              name: 'Network',
-              value: !INDEX_TESTNET ? 'Ethereum' : 'Sepolia',
-              inline: true
-            },
-            {
-              name: 'Expiration',
-              value: `<t:${space.turbo_expiration}:R>`,
-              inline: true
-            }
-          ],
-          timestamp: new Date(blockTimestamp * 1000).toISOString()
-        }
-      ]
-    })
+          {
+            name: 'Network',
+            value: !INDEX_TESTNET ? 'Ethereum' : 'Sepolia',
+            inline: true
+          },
+          {
+            name: 'Expiration',
+            value: `<t:${space.turbo_expiration}:R>`,
+            inline: true
+          }
+        ],
+        timestamp: new Date(blockTimestamp * 1000).toISOString()
+      }
+    ]
   });
-
-  return;
 }
 
 export async function sendExpirationNotification(

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import path from 'path';
 import Checkpoint, { evm, LogLevel } from '@snapshot-labs/checkpoint';
 import cors from 'cors';
 import express from 'express';
-import { createConfig } from './config';
+import { createConfig, NETWORK } from './config';
 import { startExpirationMonitor } from './expirationMonitor';
 import overrides from './overrides.json';
 import { sleep } from './utils';
@@ -19,8 +19,7 @@ if (process.env.CA_CERT) {
   process.env.CA_CERT = process.env.CA_CERT.replace(/\\n/g, '\n');
 }
 
-const network = process.env.INDEX_TESTNET ? 'sep' : 'eth';
-const config = createConfig(network);
+const config = createConfig(NETWORK);
 
 const checkpoint = new Checkpoint(schema, {
   logLevel: LogLevel.Info,
@@ -28,8 +27,8 @@ const checkpoint = new Checkpoint(schema, {
   overridesConfig: overrides
 });
 
-const indexer = new evm.EvmIndexer(createEvmWriters(network));
-checkpoint.addIndexer(network, config, indexer);
+const indexer = new evm.EvmIndexer(createEvmWriters(NETWORK));
+checkpoint.addIndexer(NETWORK, config, indexer);
 
 async function run() {
   if (process.env.NODE_ENV === 'production') {

--- a/src/writers.ts
+++ b/src/writers.ts
@@ -1,5 +1,6 @@
 import { evm } from '@snapshot-labs/checkpoint';
 import SchnapsAbi from './abis/Schnaps';
+import { TURBO_PRICE_USD } from './config';
 import { notifyPayment } from './discord';
 import tokens from './payment_tokens.json';
 import { getJSON } from './utils';
@@ -8,8 +9,8 @@ import { Payment, Space } from '../.checkpoint/models';
 const MILLISECONDS = 1000;
 const DECIMALS = 1e6; // USDC and USDT both have 6 decimals
 
-const TURBO_MONTHLY_PRICE = 600 * DECIMALS;
-const TURBO_YEARLY_PRICE = 6000 * DECIMALS;
+const TURBO_MONTHLY_PRICE = TURBO_PRICE_USD.monthly * DECIMALS;
+const TURBO_YEARLY_PRICE = TURBO_PRICE_USD.yearly * DECIMALS;
 
 const DAYS_PER_YEAR = (365 * 3 + 366) / 4; // Accounting for leap years, which happens even four year (this is technically incorrect due to leap seconds but it's good enough for this purpose)
 const YEARLY_PRICE_PER_DAY = TURBO_YEARLY_PRICE / DAYS_PER_YEAR;
@@ -33,13 +34,48 @@ function getTokenSymbol(tokenAddress: string, chain: string) {
   return tokens[chain][tokenAddress];
 }
 
-// Computes the time of expiration of a space based on the payment received.
-// The logic is as follows:
-// - Returns `null` if the payment is not enough to extend the by at least one month
-// - If the user has paid for more than a year, the expiration date is extended by the number of years paid
-//   - Then take the surplus and increase the expiration date based on the YEARLY_PRICE_PER_SECOND
-// - If the user has paid for more than a month (but less than a year), the expiration date is extended by the number of months paid
-//   - Then take the surplus and increase the expiration date based on the MONTHLY_PRICE_PER_SECOND
+// Computes the new expiration date from a payment amount.
+// Pure helper, no entity coupling — both the on-chain writer and the Stripe
+// indexer call this with primitives.
+// - Returns the current expiration unchanged if the amount is below one month
+// - If the user has paid for more than a year, extends by the number of years paid
+//   plus a per-second surplus at YEARLY_PRICE_PER_SECOND
+// - Otherwise extends by the number of months paid plus a per-second surplus
+//   at MONTHLY_PRICE_PER_SECOND
+export function computeExpirationFromAmount(
+  amountRaw: bigint,
+  currentExpiration: number,
+  timestamp: number
+): Date {
+  if (amountRaw < TURBO_MONTHLY_PRICE) {
+    if (currentExpiration) {
+      return new Date(currentExpiration * MILLISECONDS);
+    }
+    return new Date(0);
+  }
+
+  const baseTimestamp = Math.max(currentExpiration, timestamp);
+  const expirationDate = new Date(baseTimestamp * MILLISECONDS);
+
+  if (amountRaw >= TURBO_YEARLY_PRICE) {
+    const years = Number(amountRaw) / TURBO_YEARLY_PRICE;
+    expirationDate.setFullYear(expirationDate.getFullYear() + years);
+
+    const surplus = Number(amountRaw) % TURBO_YEARLY_PRICE;
+    const surplusSeconds = surplus / YEARLY_PRICE_PER_SECOND;
+    expirationDate.setSeconds(expirationDate.getSeconds() + surplusSeconds);
+  } else {
+    const months = Number(amountRaw) / TURBO_MONTHLY_PRICE;
+    expirationDate.setMonth(expirationDate.getMonth() + months);
+
+    const surplus = Number(amountRaw) % TURBO_MONTHLY_PRICE;
+    const surplusSeconds = surplus / MONTHLY_PRICE_PER_SECOND;
+    expirationDate.setSeconds(expirationDate.getSeconds() + surplusSeconds);
+  }
+
+  return expirationDate;
+}
+
 function computeExpiration(
   space: Space,
   payment: Payment,
@@ -52,53 +88,14 @@ function computeExpiration(
     payment.amount_raw == 0n
   ) {
     const date = new Date(metadata.params.expiration * MILLISECONDS);
-    if (isNaN(date.getTime())) {
-      return new Date(0);
-    } else {
-      return date;
-    }
+    return isNaN(date.getTime()) ? new Date(0) : date;
   }
 
-  if (payment.amount_raw < TURBO_MONTHLY_PRICE) {
-    // Return early because the payment is not enough to extend the expiration
-    if (space.turbo_expiration) {
-      // User already had an expiration date, leave it untouched.
-      return new Date(space.turbo_expiration * MILLISECONDS);
-    } else {
-      // User didn't have an expiration date, leave it to 0
-      return new Date(0);
-    }
-  }
-
-  // If the space already has an expiration date, use it as the current expiration date
-  const currentExpirationTimestamp = Math.max(
+  return computeExpirationFromAmount(
+    payment.amount_raw,
     space.turbo_expiration,
     blockTimestamp
   );
-  const expirationDate = new Date(currentExpirationTimestamp * MILLISECONDS); // Multiply by 1000 to convert to milliseconds
-
-  const userPaidAtLeastAYear = payment.amount_raw >= TURBO_YEARLY_PRICE;
-  if (userPaidAtLeastAYear) {
-    const years = Number(payment.amount_raw) / TURBO_YEARLY_PRICE;
-    expirationDate.setFullYear(expirationDate.getFullYear() + years);
-
-    const surplus = Number(payment.amount_raw) % TURBO_YEARLY_PRICE;
-    const surplusSeconds = surplus / YEARLY_PRICE_PER_SECOND;
-    expirationDate.setSeconds(expirationDate.getSeconds() + surplusSeconds);
-  } else if (payment.amount_raw >= TURBO_MONTHLY_PRICE) {
-    const months = Number(payment.amount_raw) / TURBO_MONTHLY_PRICE;
-    expirationDate.setMonth(expirationDate.getMonth() + months);
-
-    const surplus = Number(payment.amount_raw) % TURBO_MONTHLY_PRICE;
-    const surplusSeconds = surplus / MONTHLY_PRICE_PER_SECOND;
-    expirationDate.setSeconds(expirationDate.getSeconds() + surplusSeconds);
-  } else {
-    console.log(
-      'error, unreachable code. Payment is not enough to extend the expiration'
-    );
-  }
-
-  return expirationDate;
 }
 
 export function createEvmWriters(indexerName: string) {


### PR DESCRIPTION
## What

Behavior-preserving refactors extracted ahead of Stripe payment support (#18 stacks on this branch).

- **`writers.ts`** — extract `computeExpirationFromAmount()` as a pure helper; `computeExpiration` delegates to it. Also drops a dead `else { console.log('unreachable') }` branch and simplifies an `isNaN` ternary.
- **`discord.ts`** — extract `postToDiscord()` + `isRecent()` helpers; refactor `notifyPayment` to use them. Adds a `DiscordMessage` type.
- **`config.ts`** — extract `NETWORK` + `TURBO_PRICE_USD` constants (removes magic `600`/`6000`).
- **`index.ts`** — use `NETWORK` from config (dedup).

No behavior change — the on-chain payment path is byte-identical.

Stacked: **#18** (Stripe support) is based on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
